### PR TITLE
Add Firefox extensions

### DIFF
--- a/modules/home-manager/linux-desktop.nix
+++ b/modules/home-manager/linux-desktop.nix
@@ -291,6 +291,19 @@ in
             };
           };
         };
+        extensions = with pkgs.nur.repos.rycee.firefox-addons; [
+          ublock-origin
+          onepassword
+          sponsorblock
+          tracking-token-stripper
+          return-youtube-dislike
+          browserpass
+          dearrow
+          youtube-auto-hd
+          tabliss
+          i-still-dont-care-about-cookies
+          bypass-paywalls-clean
+        ];
       };
     };
     chromium = {


### PR DESCRIPTION
## Summary
- enable extensions in the firefox profile to match Brave

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684778736f24832aa93797d87a2c7f96